### PR TITLE
Solana endpoints support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,16 +2,35 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+export type SchemaConfig = {
+  /** Tool prefix */
+  prefix?: string;
+  /** API URL */
+  baseUrl: string;
+  /** OpenAPI URL */
+  specUrl: string;
+};
+
 /**
  * Server Environment Configuration
  */
 export class Config {
-  static SERVER_NAME: string;
-  static SERVER_VERSION: string;
+  static SERVER_NAME = process.env.SERVER_NAME || 'Moralis MCP';
+  static SERVER_VERSION = process.env.SERVER_VERSION || '1.0.0';
   static MORALIS_API_KEY = process.env.MORALIS_API_KEY;
-  static API_BASE_URL =
-    process.env.API_BASE_URL || 'https://deep-index.moralis.io/api/v2.2';
-  static API_SPEC_URL =
-    process.env.API_SPEC_URL ||
-    'https://deep-index.moralis.io/api-docs-2.2/v2.2/swagger.json';
+  static EVM_CONFIG: SchemaConfig = {
+    prefix: 'evm_',
+    baseUrl:
+      process.env.API_BASE_URL || 'https://deep-index.moralis.io/api/v2.2',
+    specUrl:
+      process.env.API_SPEC_URL ||
+      'https://deep-index.moralis.io/api-docs-2.2/v2.2/swagger.json',
+  };
+  static SOL_CONFIG: SchemaConfig = {
+    prefix: 'solana_',
+    baseUrl: process.env.SOLANA_BASE_URL || 'https://solana-gateway.moralis.io',
+    specUrl:
+      process.env.SOLANA_SPEC_URL ||
+      'https://solana-gateway.moralis.io/api-json',
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { Config } from './config.js';
-import { server } from './server.js';
+import { serverSetup } from './server.js';
 import { setupWebServer } from './web-server.js';
 import { setupStreamableHttpServer } from './streamable-http.js';
 
@@ -16,9 +16,9 @@ async function startStdioServer() {
   // Set up stdio transport
   try {
     const transport = new StdioServerTransport();
-    await server.connect(transport);
+    (await serverSetup()).connect(transport);
     console.error(
-      `${Config.SERVER_NAME} MCP Server (v${Config.SERVER_VERSION}) running on stdio${Config.API_BASE_URL ? `, proxying API at ${Config.API_BASE_URL}` : ''}`,
+      `${Config.SERVER_NAME} Server (v${Config.SERVER_VERSION}) running on stdio`,
     );
   } catch (error) {
     console.error('Error during server startup:', error);
@@ -29,7 +29,7 @@ async function startStdioServer() {
 async function startWebServer() {
   // Set up Web Server transport
   try {
-    await setupWebServer(server, 3000);
+    await setupWebServer(await serverSetup(), 3000);
   } catch (error) {
     console.error('Error setting up web server:', error);
     process.exit(1);
@@ -39,7 +39,7 @@ async function startWebServer() {
 async function startStreamableHttpServer() {
   // Set up StreamableHTTP transport
   try {
-    await setupStreamableHttpServer(server, 3000);
+    await setupStreamableHttpServer(await serverSetup(), 3000);
   } catch (error) {
     console.error('Error setting up StreamableHTTP server:', error);
     process.exit(1);

--- a/src/parser/extract-tools.ts
+++ b/src/parser/extract-tools.ts
@@ -11,10 +11,12 @@ import type { OpenAPIV3DocumentX } from '../types/open-api-document-x.js';
  * Extracts tool definitions from an OpenAPI document
  *
  * @param api OpenAPI document
+ * @param prefix Tool prefix
  * @returns Array of MCP tool definitions
  */
 export function extractToolsFromApi(
   api: OpenAPIV3DocumentX,
+  prefix?: string,
 ): McpToolDefinition[] {
   const tools: McpToolDefinition[] = [];
   const usedNames = new Set<string>();
@@ -72,7 +74,7 @@ export function extractToolsFromApi(
 
       // Create the tool definition
       tools.push({
-        name: finalToolName,
+        name: prefix + finalToolName,
         description,
         inputSchema,
         method,
@@ -199,14 +201,19 @@ export function mapOpenApiSchemaToJsonSchema(
   let jsonSchema: JSONSchema7 = { ...schema } as any;
 
   if (schema.oneOf || schema.anyOf || schema.allOf) {
-    const oneSchema = structuredClone(schema.oneOf || schema.anyOf || schema.allOf);
+    const oneSchema = structuredClone(
+      schema.oneOf || schema.anyOf || schema.allOf,
+    );
 
     if (oneSchema) {
       const combinedSchema = mapOpenApiSchemaToJsonSchema(oneSchema[0]);
-      
+
       for (let i = 1; i < oneSchema.length; i++) {
         const mappedSubSchema = mapOpenApiSchemaToJsonSchema(oneSchema[i]);
-        if (typeof mappedSubSchema === 'object' && typeof combinedSchema === 'object') {
+        if (
+          typeof mappedSubSchema === 'object' &&
+          typeof combinedSchema === 'object'
+        ) {
           // Handle enum values
           if (mappedSubSchema.enum) {
             if (!combinedSchema.enum) {
@@ -215,7 +222,7 @@ export function mapOpenApiSchemaToJsonSchema(
             // Combine enum values from both schemas
             const uniqueEnums = new Set([
               ...combinedSchema.enum,
-              ...(mappedSubSchema.enum || [])
+              ...(mappedSubSchema.enum || []),
             ]);
             combinedSchema.enum = Array.from(uniqueEnums);
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,135 +15,158 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { extractToolsFromApi } from './parser/index.js';
-import { Config } from './config.js';
+import { Config, type SchemaConfig } from './config.js';
 import { getSpec } from './utils/get-spec.js';
 import type { OpenAPIV3DocumentX } from './types/open-api-document-x.js';
-import { executeApiTool, type McpToolDefinition } from './utils/execute-api-tool.js';
+import {
+  executeApiTool,
+  type McpToolDefinition,
+} from './utils/execute-api-tool.js';
 
-const spec = (await getSpec(Config.API_SPEC_URL)) as OpenAPIV3DocumentX;
+async function mapToolDefinitions(config: SchemaConfig) {
+  const spec = (await getSpec(config.specUrl)) as OpenAPIV3DocumentX;
+  const api = (await SwaggerParser.dereference(spec)) as OpenAPIV3DocumentX;
 
-Config.SERVER_NAME = spec.info.title;
-Config.SERVER_VERSION = spec.info.version;
+  const tools = extractToolsFromApi(api, config.prefix);
+  const blacklist = Array.isArray(api['x-mcp-blacklist'])
+    ? api['x-mcp-blacklist'].map((e) => e.toLowerCase())
+    : [];
 
-/**
- * MCP Server instance
- */
-export const server = new Server(
-  { name: Config.SERVER_NAME, version: Config.SERVER_VERSION },
-  { capabilities: { tools: {}, prompts: {} } },
-);
-
-const api = (await SwaggerParser.dereference(spec)) as OpenAPIV3DocumentX;
-const tools = extractToolsFromApi(api);
-const blacklist = Array.isArray(api['x-mcp-blacklist'])
-  ? api['x-mcp-blacklist'].map((e) => e.toLowerCase())
-  : [];
-
-/**
- * Map of tool definitions by name
- */
-const toolDefinitionMap: Map<string, McpToolDefinition> = new Map();
-for (const tool of tools) {
-  if (blacklist.includes(tool.name)) {
-    continue;
+  const toolDefinitionMap: Record<string, McpToolDefinition> = {};
+  for (const tool of tools) {
+    if (blacklist.includes(tool.name)) continue;
+    toolDefinitionMap[tool.name] = {
+      ...tool,
+      baseUrl: config.baseUrl,
+    };
   }
-
-  toolDefinitionMap.set(tool.name, tool);
+  return toolDefinitionMap;
 }
 
-/**
- * Security schemes from the OpenAPI spec
- */
-const securitySchemes = {
-  ApiKeyAuth: {
-    type: 'apiKey',
-    in: 'header',
-    name: 'X-API-Key',
-    'x-default': 'test',
-  },
-};
+export async function serverSetup(
+  config: SchemaConfig | SchemaConfig[] = [
+    Config.EVM_CONFIG,
+    Config.SOL_CONFIG,
+  ],
+) {
+  const configArray = Array.isArray(config) ? config : [config];
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const toolsForClient: Tool[] = Array.from(toolDefinitionMap.values()).map(
-    (def) => ({
-      name: def.name,
-      description: def.description,
-      inputSchema: def.inputSchema,
-    }),
+  /**
+   * MCP Server instance
+   */
+  const server = new Server(
+    { name: Config.SERVER_NAME, version: Config.SERVER_VERSION },
+    { capabilities: { tools: {}, prompts: {} } },
   );
-  return { tools: toolsForClient };
-});
 
-server.setRequestHandler(
-  CallToolRequestSchema,
-  async (request: CallToolRequest, c): Promise<CallToolResult> => {
-    const { name: toolName, arguments: toolArgs } = request.params;
-    const toolDefinition = toolDefinitionMap.get(toolName);
-    if (!toolDefinition) {
-      console.error(`Error: Unknown tool requested: ${toolName}`);
-      return {
-        content: [
-          { type: 'text', text: `Error: Unknown tool requested: ${toolName}` },
-        ],
-      };
-    }
-    return executeApiTool(
-      toolName,
-      toolDefinition,
-      toolArgs ?? {},
-      securitySchemes,
-      c.authInfo?.token,
-    );
-  },
-);
-
-server.setRequestHandler(ListPromptsRequestSchema, async () => {
-  const promptsForClient: Prompt[] = [];
-  for (const tool of toolDefinitionMap.values()) {
-    if (tool.prompt) {
-      promptsForClient.push({
-        name: tool.name,
-        description: tool.prompt,
-        arguments: tool.parameters,
-      });
-    }
-  }
-
-  return { prompts: promptsForClient };
-});
-
-server.setRequestHandler(
-  GetPromptRequestSchema,
-  async (request: GetPromptRequest, c): Promise<GetPromptResult> => {
-    const { name: toolName, arguments: toolArgs } = request.params;
-    const toolDefinition = toolDefinitionMap.get(toolName);
-    if (!toolDefinition) {
-      console.error(`Error: Unknown prompt requested: ${toolName}`);
-      return {
-        messages: [
-          {
-            role: 'user',
-            content: {
-              type: 'text',
-              text: `Error: Unknown prompt requested: ${toolName}`,
-            },
-          },
-        ],
-      };
-    }
-    const toolResult = await executeApiTool(
-      toolName,
-      toolDefinition,
-      toolArgs ?? {},
-      securitySchemes,
-      c.authInfo?.token,
-    );
-
-    return {
-      messages: toolResult.content.map((content) => ({
-        role: 'user',
-        content,
-      })),
+  /**
+   * Map of tool definitions by name
+   */
+  let toolDefinitionMap: Record<string, McpToolDefinition> = {};
+  for (const config of configArray)
+    toolDefinitionMap = {
+      ...toolDefinitionMap,
+      ...(await mapToolDefinitions(config)),
     };
-  },
-);
+
+  /**
+   * Security schemes from the OpenAPI spec
+   */
+  const securitySchemes = {
+    ApiKeyAuth: {
+      type: 'apiKey',
+      in: 'header',
+      name: 'X-API-Key',
+      'x-default': 'test',
+    },
+  };
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const toolsForClient: Tool[] = Object.values(toolDefinitionMap).map(
+      (def) => ({
+        name: def.name,
+        description: def.description,
+        inputSchema: def.inputSchema,
+      }),
+    );
+    return { tools: toolsForClient };
+  });
+
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request: CallToolRequest, c): Promise<CallToolResult> => {
+      const { name: toolName, arguments: toolArgs } = request.params;
+      const toolDefinition = toolDefinitionMap[toolName];
+      if (!toolDefinition) {
+        console.error(`Error: Unknown tool requested: ${toolName}`);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: Unknown tool requested: ${toolName}`,
+            },
+          ],
+        };
+      }
+      return executeApiTool(
+        toolName,
+        toolDefinition,
+        toolArgs ?? {},
+        securitySchemes,
+        c.authInfo?.token,
+      );
+    },
+  );
+
+  server.setRequestHandler(ListPromptsRequestSchema, async () => {
+    const promptsForClient: Prompt[] = [];
+    for (const tool of Object.values(toolDefinitionMap)) {
+      if (tool.prompt) {
+        promptsForClient.push({
+          name: tool.name,
+          description: tool.prompt,
+          arguments: tool.parameters,
+        });
+      }
+    }
+
+    return { prompts: promptsForClient };
+  });
+
+  server.setRequestHandler(
+    GetPromptRequestSchema,
+    async (request: GetPromptRequest, c): Promise<GetPromptResult> => {
+      const { name: toolName, arguments: toolArgs } = request.params;
+      const toolDefinition = toolDefinitionMap[toolName];
+      if (!toolDefinition) {
+        console.error(`Error: Unknown prompt requested: ${toolName}`);
+        return {
+          messages: [
+            {
+              role: 'user',
+              content: {
+                type: 'text',
+                text: `Error: Unknown prompt requested: ${toolName}`,
+              },
+            },
+          ],
+        };
+      }
+      const toolResult = await executeApiTool(
+        toolName,
+        toolDefinition,
+        toolArgs ?? {},
+        securitySchemes,
+        c.authInfo?.token,
+      );
+
+      return {
+        messages: toolResult.content.map((content) => ({
+          role: 'user',
+          content,
+        })),
+      };
+    },
+  );
+  return server;
+}

--- a/src/utils/execute-api-tool.ts
+++ b/src/utils/execute-api-tool.ts
@@ -19,6 +19,7 @@ export interface McpToolDefinition {
   securityRequirements: any[];
   prompt?: string;
   parameters: any[];
+  baseUrl: string;
 }
 
 /**
@@ -98,9 +99,7 @@ export async function executeApiTool(
     }
 
     // Construct the full URL
-    const requestUrl = Config.API_BASE_URL
-      ? `${Config.API_BASE_URL}${urlPath}`
-      : urlPath;
+    const requestUrl = `${definition.baseUrl}${urlPath}`;
 
     // Handle request body if needed
     if (


### PR DESCRIPTION
Consume endpoints from https://solana-gateway.moralis.io/api. 

Each swagger document consumed adds a prefix to each tool generated from it.

## Claude

#### Price

```
> How does the ETH and SOL token price compare
● I'll get the current token prices for ETH and SOL to compare them.
● moralis-mcp - evm_gettokenprice (MCP)(address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", chain: "eth")
● moralis-mcp - solana_gettokenprice (MCP)(network: "mainnet", address: "So11111111111111111111111111111111111111112")
```

#### Exchange
```
> Get new tokens added to pump.fun
● I'll get the new tokens added to pump.fun. This exchange is typically on Solana, so I'll try the Solana API.
● moralis-mcp - solana_getnewtokensbyexchange (MCP)(network: "mainnet", exchange: "pump.fun")
```

#### NFT

EVM (default)
```
> Get NFTs owned by 0xcB1C1FdE09f811B294172696404e88E658659905
● I'll get the NFTs owned by that Ethereum address.
● moralis-mcp - evm_getwalletnfts (MCP)(address: "0xcB1C1FdE09f811B294172696404e88E658659905", chain: "eth")
```

Solana
```
> Get NFTs owned by 0xcB1C1FdE09f811B294172696404e88E658659905 on solana
● I'll get the NFTs owned by that address on Solana.
● moralis-mcp - solana_getnfts (MCP)(network: "mainnet", address: "0xcB1C1FdE09f811B294172696404e88E658659905")
```